### PR TITLE
Emit error signal when av_read_frame fails

### DIFF
--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -108,6 +108,7 @@ public:
     bool eof = false;
     QList<QAVPacket> packets;
     QString bsfs;
+    int lastError = 0;
 };
 
 static void log_callback(void *ptr, int level, const char *fmt, va_list vl)
@@ -683,11 +684,19 @@ QAVPacket QAVDemuxer::read()
 
     QAVPacket pkt;
     bool eof = false;
+    {
+        QMutexLocker locker(&d->mutex);
+        d->lastError = 0;
+    }
     int ret = av_read_frame(d->ctx, pkt.packet());
     if (ret < 0) {
         if (ret == AVERROR_EOF || avio_feof(d->ctx->pb)) {
             eof = true;
         } else {
+            {
+                QMutexLocker locker(&d->mutex);
+                d->lastError = ret;
+            }
             qDebug() << "av_read_frame: unexpected result:" << ret;
             return {};
         }
@@ -711,6 +720,13 @@ QAVPacket QAVDemuxer::read()
         }
     }
     return pkt;
+}
+
+int QAVDemuxer::lastError() const
+{
+    Q_D(const QAVDemuxer);
+    QMutexLocker locker(&d->mutex);
+    return d->lastError;
 }
 
 void QAVDemuxer::decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const

--- a/src/QtAVPlayer/qavdemuxer_p.h
+++ b/src/QtAVPlayer/qavdemuxer_p.h
@@ -67,6 +67,7 @@ public:
     AVFormatContext *avctx() const;
 
     QAVPacket read();
+    int lastError() const;
 
     void decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const;
     void decode(const QAVPacket &pkt, QList<QAVSubtitleFrame> &frames) const;

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -637,6 +637,10 @@ void QAVPlayerPrivate::doDemux()
                     break;
             }
         } else {
+            if (int err = demuxer.lastError()) {
+                setError(QAVPlayer::ResourceError, QLatin1String("av_read_frame: unexpected result: ") + err_str(err));
+                return;
+            }
             if (demuxer.eof()
                 && videoQueue.isEmpty()
                 && audioQueue.isEmpty()


### PR DESCRIPTION
## Summary
- track last error in QAVDemuxer::read
- emit QAVPlayer errorOccurred when av_read_frame returns unexpected result

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1015a2ed8832bab1d271a31be62a5