### PR TITLE
Prioritize DRM PRIME pixel format on Linux

### DIFF
--- a/src/QtAVPlayer/qavvideocodec.cpp
+++ b/src/QtAVPlayer/qavvideocodec.cpp
@@ -102,6 +102,12 @@ static AVPixelFormat negotiate_pixel_format(AVCodecContext *c, const AVPixelForm
 
     AVPixelFormat pf = !softwareFormats.isEmpty() ? softwareFormats[0] : AV_PIX_FMT_NONE;
     const char *decStr = "software";
+#if defined(Q_OS_LINUX)
+    if (hardwareFormats.contains(AV_PIX_FMT_DRM_PRIME)) {
+        pf = AV_PIX_FMT_DRM_PRIME;
+        decStr = "hardware";
+    } else
+#endif
     if (d->hw_device) {
         for (auto f : hardwareFormats) {
             if (f == d->hw_device->format()) {


### PR DESCRIPTION
## Summary
- Prefer AV_PIX_FMT_DRM_PRIME in negotiate_pixel_format when running on Linux

## Testing
- `cd tests/auto/integration/qavplayer && qmake && make check` *(fails: command not found: qmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c002a8c644832b9a96507d4cbe06c6