### PR TITLE
Prevent video frames after stop

### DIFF
--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -22,6 +22,7 @@
 #include <QtConcurrent/qtconcurrentrun.h>
 #include <QLoggingCategory>
 #include <functional>
+#include <atomic>
 
 extern "C" {
 #include <libavformat/avformat.h>
@@ -158,6 +159,7 @@ public:
     QWaitCondition waitCond;
     bool eof = false;
     std::atomic_bool startDemuxing {false};
+    std::atomic_bool stopPending {false};
 
     QList<QString> filterDescs;
     QAVFilters filters;
@@ -199,6 +201,7 @@ void QAVPlayerPrivate::resetPendingStatuses()
     qCDebug(lcAVPlayer) << __FUNCTION__ << ":" << pendingMediaStatuses;
     pendingMediaStatuses.clear();
     wait(true);
+    stopPending.store(false, std::memory_order_release);
 }
 
 void QAVPlayerPrivate::setPendingMediaStatus(PendingMediaStatus status)
@@ -206,6 +209,8 @@ void QAVPlayerPrivate::setPendingMediaStatus(PendingMediaStatus status)
     QMutexLocker locker(&stateMutex);
     pendingMediaStatuses.push_back(status);
     qCDebug(lcAVPlayer) << __FUNCTION__ << ":" << mediaStatus << "->" << pendingMediaStatuses;
+    if (status == StoppingMedia)
+        stopPending.store(true, std::memory_order_release);
 }
 
 bool QAVPlayerPrivate::setState(QAVPlayer::State s)
@@ -351,6 +356,7 @@ void QAVPlayerPrivate::terminate()
     dev.reset();
     eof = false;
     startDemuxing = false;
+    stopPending.store(false, std::memory_order_release);
 }
 
 void QAVPlayerPrivate::step(bool hasFrame)
@@ -418,6 +424,7 @@ bool QAVPlayerPrivate::doStep(PendingMediaStatus status, bool hasFrame)
                 result = true;
                 qCDebug(lcAVPlayer) << "Stopped to pos:" << q_ptr->position();
                 Q_EMIT q_ptr->stopped(q_ptr->position());
+                stopPending.store(false, std::memory_order_release);
                 wait(true);
             }
             break;
@@ -781,7 +788,10 @@ void QAVPlayerPrivate::doPlayStep(
                     setPts(frame.pts());
                 if (!flushEvents)
                     flushEvents = true;
-                cb(frame);
+                const bool stopVideoPending = stopPending.load(std::memory_order_acquire)
+                    && queue.mediaType() == AVMEDIA_TYPE_VIDEO;
+                if (!stopVideoPending)
+                    cb(frame);
                 demuxer.onFrameSent(frame);
             }
             filteredFrames.pop_front();

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -938,13 +938,32 @@ void tst_QAVPlayer::videoFrame()
     p.setSource(file.absoluteFilePath());
 
     QAVVideoFrame frame;
-    QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&frame](const QAVVideoFrame &f) { frame = f; });
+    int framesCount = 0;
+    int framesAfterStop = 0;
+    bool stopIssued = false;
+    QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &f) {
+        frame = f;
+        if (!f)
+            return;
+        ++framesCount;
+        if (stopIssued)
+            ++framesAfterStop;
+    });
 
     p.play();
     QTRY_VERIFY(!frame.size().isEmpty());
     QTRY_COMPARE(p.mediaStatus(), QAVPlayer::LoadedMedia);
 
+    const int framesBeforeStop = framesCount;
+    stopIssued = true;
+    
     p.stop();
+    QTRY_COMPARE(p.state(), QAVPlayer::StoppedState);
+    QTRY_COMPARE(p.mediaStatus(), QAVPlayer::LoadedMedia);
+
+    QTest::qWait(200);
+    QCOMPARE(framesAfterStop, 0);
+    QCOMPARE(framesCount, framesBeforeStop);
 }
 
 void tst_QAVPlayer::pauseSeekVideo()


### PR DESCRIPTION
## Summary
- add an atomic flag in QAVPlayerPrivate to record pending stops and reset it when stopping completes
- skip dispatching video frames when a stop is pending so clients do not receive extra frames
- extend the integration test to ensure no video frames are emitted after stop()

## Testing
- ctest (fails: No test configuration file found)

------
https://chatgpt.com/codex/tasks/task_e_68cd0111ea94832bb32064e0b554b8ae